### PR TITLE
Fixed directory delimiter in zip-files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # action: ['run-tests', 'compile-examples']
         action: ['compile-examples']
         name:
           # - Ubuntu 16.04 GCC
@@ -105,7 +104,7 @@ jobs:
         run: |
           mkdir ${{ matrix.build-dir || '.not-used' }}
           cd ${{ matrix.build-dir || '.' }}
-          cmake ${{ matrix.build-src-dir || '.' }} ${{ steps.should-test.outputs.TEST-FLAGS }} ${{ matrix.cmake-args }}
+          cmake ${{ matrix.build-src-dir || '.' }} ${{ matrix.cmake-args }}
         env:
           CC: ${{ matrix.compiler }}
           CXX: ${{ matrix.cpp-compiler }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         # action: ['run-tests', 'compile-examples']
-		action: ['compile-examples']
+        action: ['compile-examples']
         name:
           # - Ubuntu 16.04 GCC
           # - Ubuntu 16.04 Clang

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           mkdir ${{ matrix.build-dir || '.not-used' }}
           cd ${{ matrix.build-dir || '.' }}
-          cmake ${{ matrix.build-src-dir || '.' }} ${{ steps.should-test.TEST-FLAGS }} ${{ matrix.cmake-args }}
+          cmake ${{ matrix.build-src-dir || '.' }} ${{ steps.should-test.outputs.TEST-FLAGS }} ${{ matrix.cmake-args }}
         env:
           CC: ${{ matrix.compiler }}
           CXX: ${{ matrix.cpp-compiler }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,8 @@ jobs:
         if: matrix.action == 'run-tests'
         run: |
           cd ${{ matrix.build-dir || '.' }}
-          ctest -C ${{ matrix.build-config || 'Release' }} --output-on-failure
-
+		  ./Release/runUnitTests.exe
+		shell: bash
       - name: Compile C examples
         if: ( runner.os == 'Linux' || runner.os == 'macOS' ) && matrix.action == 'compile-examples'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        action: ['run-tests', 'compile-examples']
+        # action: ['run-tests', 'compile-examples']
+		action: ['compile-examples']
         name:
           # - Ubuntu 16.04 GCC
           # - Ubuntu 16.04 Clang
@@ -56,7 +57,7 @@ jobs:
             cmake-args: -DBUILD_SHARED_LIBS=OFF -Dgtest_force_shared_crt=on
             build-dir: build
             build-src-dir: ..
-            executable-extension: .exe
+            #executable-extension: .exe
 
           # - name: Windows 2019 GCC
           #   os: windows-2019
@@ -134,8 +135,7 @@ jobs:
           CXX: ${{ matrix.cpp-compiler }}
           CFLAGS: ${{ matrix.cflags || env.CFLAGS }}
           CXXFLAGS: ${{ matrix.cxxflags || env.CXXFLAGS }}
-          LDFLAGS: ${{ matrix.ldflags || env.LDFLAGS }} -lstdc++
-
+          LDFLAGS: ${{ matrix.ldflags || env.LDFLAGS }}
       - name: Compile C++ examples
         if: ( runner.os == 'Linux' || runner.os == 'macOS' ) && matrix.action == 'compile-examples'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
           CXX: ${{ matrix.cpp-compiler }}
           CFLAGS: ${{ matrix.cflags || env.CFLAGS }}
           CXXFLAGS: ${{ matrix.cxxflags || env.CXXFLAGS }}
-          LDFLAGS: ${{ matrix.ldflags || env.LDFLAGS }}
+          LDFLAGS: ${{ matrix.ldflags || env.LDFLAGS }} -lstdc++
 
       - name: Compile C++ examples
         if: ( runner.os == 'Linux' || runner.os == 'macOS' ) && matrix.action == 'compile-examples'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,8 @@ jobs:
         if: matrix.action == 'run-tests'
         run: |
           cd ${{ matrix.build-dir || '.' }}
-		  ./Release/runUnitTests.exe
-		shell: bash
+          ./Release/runUnitTests.exe
+        shell: bash
       - name: Compile C examples
         if: ( runner.os == 'Linux' || runner.os == 'macOS' ) && matrix.action == 'compile-examples'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
             cmake-args: -DBUILD_SHARED_LIBS=OFF -Dgtest_force_shared_crt=on
             build-dir: build
             build-src-dir: ..
+            executable-extension: .exe
 
           # - name: Windows 2019 GCC
           #   os: windows-2019
@@ -120,7 +121,7 @@ jobs:
         if: matrix.action == 'run-tests'
         run: |
           cd ${{ matrix.build-dir || '.' }}
-          ./Release/runUnitTests.exe
+          ./Release/runUnitTests${{ matrix.executable-extension || '' }}
         shell: bash
       - name: Compile C examples
         if: ( runner.os == 'Linux' || runner.os == 'macOS' ) && matrix.action == 'compile-examples'

--- a/include/wrappers/MinizipWrapper.h
+++ b/include/wrappers/MinizipWrapper.h
@@ -15,6 +15,8 @@ namespace modio
     void extract(std::string zip_path, std::string directory_path);
     void compressDirectory(std::string directory, std::string zip_path);
     void compressFiles(std::string root_directory, std::vector<std::string> filenames, std::string zip_path);
+    // Internal function used for testing only
+    std::vector<std::string> getZipFilenames(const std::string& zip_path);
   }
 }
 

--- a/src/wrappers/MinizipWrapper.cpp
+++ b/src/wrappers/MinizipWrapper.cpp
@@ -1,46 +1,43 @@
 #include "wrappers/MinizipWrapper.h"
-#include <stdio.h>                                     // for NULL, fclose
-#include <stdlib.h>                                    // for free, malloc
-#include <string.h>                                    // for strcat, strcpy
-#include <iostream>                                    // for char_traits
-#include "c/ModioC.h"                                  // for MODIO_DEBUGLEV...
-#include "miniz.h"                                     // for MAX_WBITS, Z_D...
-#include "Utility.h"                       // for writeLogLine
+#include "Utility.h"  // for writeLogLine
+#include "c/ModioC.h" // for MODIO_DEBUGLEV...
 #include "ghc/filesystem.hpp"
+#include "miniz.h"  // for MAX_WBITS, Z_D...
+#include <iostream> // for char_traits
+#include <stdio.h>  // for NULL, fclose
+#include <stdlib.h> // for free, malloc
+#include <string.h> // for strcat, strcpy
 
 #ifdef MODIO_WINDOWS_DETECTED
 #define USEWIN32IOAPI
-#include "dependencies/minizip/iowin32.c"
 #include "../WindowsFilesystem.h"
+#include "dependencies/minizip/iowin32.c"
 #endif
-#include "dependencies/minizip/minizip.h"  // for filetime, is_l...
-#include "dependencies/minizip/unzip.h"    // for unzClose, unzC...
-#include "dependencies/minizip/zip.h"      // for ZIP_OK, zipClose
 #include "../Filesystem.h"
+#include "dependencies/minizip/minizip.h" // for filetime, is_l...
+#include "dependencies/minizip/unzip.h"   // for unzClose, unzC...
+#include "dependencies/minizip/zip.h"     // for ZIP_OK, zipClose
 
-static const std::uint32_t UTF8_FLAG = (1<<11);
+static const std::uint32_t UTF8_FLAG = (1 << 11);
 
-namespace modio
-{
-namespace minizipwrapper
-{
-std::vector<std::string> getZipFilenames(const std::string& zip_path)
-{
+namespace modio {
+namespace minizipwrapper {
+std::vector<std::string> getZipFilenames(const std::string &zip_path) {
   std::vector<std::string> filenames;
 
 #ifdef USEWIN32IOAPI
-  zlib_filefunc64_def ffunc = { 0 };
+  zlib_filefunc64_def ffunc = {0};
 #endif
 
 #ifdef USEWIN32IOAPI
   fill_win32_filefunc64W(&ffunc);
-  unzFile zipfile = unzOpen2_64(modio::platform::utf8ToWstr(zip_path).c_str(), &ffunc);
+  unzFile zipfile =
+      unzOpen2_64(modio::platform::utf8ToWstr(zip_path).c_str(), &ffunc);
 #else
   unzFile zipfile = unzOpen(zip_path.c_str());
 #endif
 
-  if (zipfile == NULL)
-  {
+  if (zipfile == NULL) {
     writeLogLine("Cannot open " + zip_path, MODIO_DEBUGLEVEL_ERROR);
     return filenames;
   }
@@ -49,8 +46,7 @@ std::vector<std::string> getZipFilenames(const std::string& zip_path)
   unzGetGlobalInfo(zipfile, &global_info);
 
   uLong i;
-  for (i = 0; i < global_info.number_entry; ++i)
-  {
+  for (i = 0; i < global_info.number_entry; ++i) {
     unz_file_info file_info;
 
     int err;
@@ -60,39 +56,33 @@ std::vector<std::string> getZipFilenames(const std::string& zip_path)
     {
       char filename[MAX_FILENAME];
 
-      err = unzGetCurrentFileInfo(
-        zipfile,
-        &file_info,
-        filename,
-        MAX_FILENAME,
-        NULL, 0, NULL, 0);
+      err = unzGetCurrentFileInfo(zipfile, &file_info, filename, MAX_FILENAME,
+                                  NULL, 0, NULL, 0);
 
-      if (err != UNZ_OK)
-      {
+      if (err != UNZ_OK) {
         unzClose(zipfile);
-        writeLogLine("error " + toString(err) + " with zipfile in unzGetCurrentFileInfo", MODIO_DEBUGLEVEL_ERROR);
+        writeLogLine("error " + toString(err) +
+                         " with zipfile in unzGetCurrentFileInfo",
+                     MODIO_DEBUGLEVEL_ERROR);
         return filenames;
       }
 
       // Is the name encoded in UTF8 or CP437
-      if (file_info.flag & UTF8_FLAG)
-      {
+      if (file_info.flag & UTF8_FLAG) {
         utf8_encoded_filename = filename;
-      }
-      else
-      {
+      } else {
         utf8_encoded_filename = modio::CP437ToUTF8(filename);
       }
 
       filenames.push_back(utf8_encoded_filename);
 
-      if ((i + 1) < global_info.number_entry)
-      {
+      if ((i + 1) < global_info.number_entry) {
         err = unzGoToNextFile(zipfile);
 
-        if (err != UNZ_OK)
-        {
-          writeLogLine("error " + toString(err) + " with zipfile in unzGoToNextFile", MODIO_DEBUGLEVEL_ERROR);
+        if (err != UNZ_OK) {
+          writeLogLine("error " + toString(err) +
+                           " with zipfile in unzGoToNextFile",
+                       MODIO_DEBUGLEVEL_ERROR);
           unzClose(zipfile);
           return filenames;
         }
@@ -104,25 +94,23 @@ std::vector<std::string> getZipFilenames(const std::string& zip_path)
   return filenames;
 }
 
-
-void extract(std::string zip_path, std::string directory_path)
-{
+void extract(std::string zip_path, std::string directory_path) {
   directory_path = addSlashIfNeeded(directory_path);
-  
+
 #ifdef USEWIN32IOAPI
-  zlib_filefunc64_def ffunc = { 0 };
+  zlib_filefunc64_def ffunc = {0};
 #endif
 
   writeLogLine(std::string("Extracting ") + zip_path, MODIO_DEBUGLEVEL_LOG);
 #ifdef USEWIN32IOAPI
   fill_win32_filefunc64W(&ffunc);
-  unzFile zipfile = unzOpen2_64(modio::platform::utf8ToWstr(zip_path).c_str(), &ffunc);
+  unzFile zipfile =
+      unzOpen2_64(modio::platform::utf8ToWstr(zip_path).c_str(), &ffunc);
 #else
   unzFile zipfile = unzOpen(zip_path.c_str());
 #endif
 
-  if (zipfile == NULL)
-  {
+  if (zipfile == NULL) {
     writeLogLine("Cannot open " + zip_path, MODIO_DEBUGLEVEL_ERROR);
     return;
   }
@@ -132,8 +120,7 @@ void extract(std::string zip_path, std::string directory_path)
   char read_buffer[READ_SIZE];
 
   uLong i;
-  for (i = 0; i < global_info.number_entry; ++i)
-  {
+  for (i = 0; i < global_info.number_entry; ++i) {
     unz_file_info file_info;
 
     int err;
@@ -141,77 +128,69 @@ void extract(std::string zip_path, std::string directory_path)
     char final_filename[MAX_FILENAME];
     // Ensure that filename isn't used after this scope
     {
-		char filename[MAX_FILENAME];
+      char filename[MAX_FILENAME];
 
-		err = unzGetCurrentFileInfo(
-			zipfile,
-			&file_info,
-			filename,
-			MAX_FILENAME,
-			NULL, 0, NULL, 0);
+      err = unzGetCurrentFileInfo(zipfile, &file_info, filename, MAX_FILENAME,
+                                  NULL, 0, NULL, 0);
 
-		if (err != UNZ_OK)
-		{
-			unzClose(zipfile);
-			writeLogLine("error " + toString(err) + " with zipfile in unzGetCurrentFileInfo", MODIO_DEBUGLEVEL_ERROR);
-			return;
-		}
-    
-        // Is the name encoded in UTF8 or CP437
-        if(file_info.flag & UTF8_FLAG)
-        {
-            utf8_encoded_filename = filename;
-        }
-        else
-        {
-            utf8_encoded_filename = modio::CP437ToUTF8(filename);
-        }
+      if (err != UNZ_OK) {
+        unzClose(zipfile);
+        writeLogLine("error " + toString(err) +
+                         " with zipfile in unzGetCurrentFileInfo",
+                     MODIO_DEBUGLEVEL_ERROR);
+        return;
+      }
+
+      // Is the name encoded in UTF8 or CP437
+      if (file_info.flag & UTF8_FLAG) {
+        utf8_encoded_filename = filename;
+      } else {
+        utf8_encoded_filename = modio::CP437ToUTF8(filename);
+      }
     }
 
     strcpy(final_filename, directory_path.c_str());
     strcat(final_filename, utf8_encoded_filename.c_str());
 
     modio::createPath(directory_path + utf8_encoded_filename);
-    
-    if (utf8_encoded_filename[utf8_encoded_filename.size()-1] == dir_delimter)
-    {
+
+    if (utf8_encoded_filename[utf8_encoded_filename.size() - 1] ==
+        dir_delimter) {
       modio::createDirectory(final_filename);
-    }
-    else
-    {
+    } else {
       err = unzOpenCurrentFile(zipfile);
 
-      if (err != UNZ_OK)
-      {
-        writeLogLine(std::string("Cannot open ") + utf8_encoded_filename, MODIO_DEBUGLEVEL_ERROR);
+      if (err != UNZ_OK) {
+        writeLogLine(std::string("Cannot open ") + utf8_encoded_filename,
+                     MODIO_DEBUGLEVEL_ERROR);
         return;
       }
 
       FILE *out;
       out = modio::platform::fopen(final_filename, "wb");
 
-      if (!out)
-      {
-        writeLogLine(std::string("error opening ") + utf8_encoded_filename, MODIO_DEBUGLEVEL_ERROR);
+      if (!out) {
+        writeLogLine(std::string("error opening ") + utf8_encoded_filename,
+                     MODIO_DEBUGLEVEL_ERROR);
         return;
       }
 
       err = UNZ_OK;
-      do
-      {
+      do {
         err = unzReadCurrentFile(zipfile, read_buffer, READ_SIZE);
-        if (err < 0)
-        {
-          writeLogLine("error " + toString(err) + " with zipfile in unzReadCurrentFile", MODIO_DEBUGLEVEL_ERROR);
+        if (err < 0) {
+          writeLogLine("error " + toString(err) +
+                           " with zipfile in unzReadCurrentFile",
+                       MODIO_DEBUGLEVEL_ERROR);
           unzCloseCurrentFile(zipfile);
           unzClose(zipfile);
           return;
         }
-        if (err > 0)
-        {
-          if (fwrite(read_buffer, (size_t)err, 1, out) != 1)
-          {
-            writeLogLine("error " + toString(err) + " in writing extracted file", MODIO_DEBUGLEVEL_ERROR);
+        if (err > 0) {
+          if (fwrite(read_buffer, (size_t)err, 1, out) != 1) {
+            writeLogLine("error " + toString(err) +
+                             " in writing extracted file",
+                         MODIO_DEBUGLEVEL_ERROR);
           }
         }
       } while (err > 0);
@@ -220,16 +199,18 @@ void extract(std::string zip_path, std::string directory_path)
 
       err = unzCloseCurrentFile(zipfile);
       if (err != UNZ_OK)
-        writeLogLine("error " + toString(err) + " with " + utf8_encoded_filename + " in unzCloseCurrentFile", MODIO_DEBUGLEVEL_ERROR);
+        writeLogLine("error " + toString(err) + " with " +
+                         utf8_encoded_filename + " in unzCloseCurrentFile",
+                     MODIO_DEBUGLEVEL_ERROR);
     }
 
-    if ((i + 1) < global_info.number_entry)
-    {
+    if ((i + 1) < global_info.number_entry) {
       err = unzGoToNextFile(zipfile);
 
-      if (err != UNZ_OK)
-      {
-        writeLogLine("error " + toString(err) + " with zipfile in unzGoToNextFile", MODIO_DEBUGLEVEL_ERROR);
+      if (err != UNZ_OK) {
+        writeLogLine("error " + toString(err) +
+                         " with zipfile in unzGoToNextFile",
+                     MODIO_DEBUGLEVEL_ERROR);
         unzClose(zipfile);
         return;
       }
@@ -239,16 +220,16 @@ void extract(std::string zip_path, std::string directory_path)
   writeLogLine(zip_path + " extracted", MODIO_DEBUGLEVEL_LOG);
 }
 
-void getFileTimeWrapper( const std::string& fileName, zip_fileinfo& out_fileInfo )
-{
+void getFileTimeWrapper(const std::string &fileName,
+                        zip_fileinfo &out_fileInfo) {
   std::error_code ec;
   ghc::filesystem::directory_entry fileInfo(fileName, ec);
-  if( !ec )
-  {
+  if (!ec) {
     auto lastWriteTime = fileInfo.last_write_time();
-    std::time_t ctime = decltype(lastWriteTime)::clock::to_time_t(lastWriteTime);
+    std::time_t ctime =
+        decltype(lastWriteTime)::clock::to_time_t(lastWriteTime);
 
-    struct tm* filedate = localtime(&ctime);
+    struct tm *filedate = localtime(&ctime);
 
     out_fileInfo.dosDate = 0;
     out_fileInfo.tmz_date.tm_sec = filedate->tm_sec;
@@ -260,31 +241,33 @@ void getFileTimeWrapper( const std::string& fileName, zip_fileinfo& out_fileInfo
   }
 }
 
-bool getIsLargeFile( const std::string& fileName )
-{
+bool getIsLargeFile(const std::string &fileName) {
   std::error_code ec;
   ghc::filesystem::directory_entry fileInfo(fileName, ec);
-  if( !ec )
-  {
+  if (!ec) {
     return fileInfo.file_size() > 0xffffffff;
   }
   // If the file doesn't exist, it's not a large file
   return false;
 }
 
-void compressFiles(std::string root_directory, std::vector<std::string> filenames, std::string zip_path)
-{
-  // Users might pass in directories without slashes, and we use root_directory + filename in a few places
+void compressFiles(std::string root_directory,
+                   std::vector<std::string> filenames, std::string zip_path) {
+  // Users might pass in directories without slashes, and we use root_directory
+  // + filename in a few places
   root_directory = modio::addSlashIfNeeded(root_directory);
 
-  writeLogLine("Compressing " + modio::toString((u32)filenames.size()) + " files", MODIO_DEBUGLEVEL_LOG);
+  writeLogLine("Compressing " + modio::toString((u32)filenames.size()) +
+                   " files",
+               MODIO_DEBUGLEVEL_LOG);
 
-  writeLogLine(std::string("Compressing ") + " into " + zip_path, MODIO_DEBUGLEVEL_LOG);
+  writeLogLine(std::string("Compressing ") + " into " + zip_path,
+               MODIO_DEBUGLEVEL_LOG);
 
   zipFile zf = NULL;
-  #ifdef USEWIN32IOAPI
-    zlib_filefunc64_def ffunc = {0};
-  #endif
+#ifdef USEWIN32IOAPI
+  zlib_filefunc64_def ffunc = {0};
+#endif
   const char *zipfilename = zip_path.c_str();
   const char *password = NULL;
   void *buf = NULL;
@@ -296,29 +279,26 @@ void compressFiles(std::string root_directory, std::vector<std::string> filename
   int opt_exclude_path = 0;
 
   buf = malloc(size_buf);
-  if (buf == NULL)
-  {
+  if (buf == NULL) {
     writeLogLine("Error allocating memory", MODIO_DEBUGLEVEL_ERROR);
   }
 
-  #ifdef USEWIN32IOAPI
-    fill_win32_filefunc64W(&ffunc);
-    zf = zipOpen2_64(modio::windows_platform::utf8ToWstr(zip_path).c_str(), opt_overwrite, NULL, &ffunc);
-  #else
-    zf = zipOpen64(zipfilename, opt_overwrite);
-  #endif
+#ifdef USEWIN32IOAPI
+  fill_win32_filefunc64W(&ffunc);
+  zf = zipOpen2_64(modio::windows_platform::utf8ToWstr(zip_path).c_str(),
+                   opt_overwrite, NULL, &ffunc);
+#else
+  zf = zipOpen64(zipfilename, opt_overwrite);
+#endif
 
-  if (zf == NULL)
-  {
-    writeLogLine(std::string("Could not open ") + zipfilename, MODIO_DEBUGLEVEL_ERROR);
-  }
-  else
-  {
+  if (zf == NULL) {
+    writeLogLine(std::string("Could not open ") + zipfilename,
+                 MODIO_DEBUGLEVEL_ERROR);
+  } else {
     writeLogLine(std::string("Creating ") + zipfilename, MODIO_DEBUGLEVEL_LOG);
   }
 
-  for (size_t i = 0; i < filenames.size(); i++)
-  {
+  for (size_t i = 0; i < filenames.size(); i++) {
     if (filenames[i] == "modio.json")
       continue;
     std::string filename = filenames[i];
@@ -327,7 +307,7 @@ void compressFiles(std::string root_directory, std::vector<std::string> filename
     size_t size_read = 0;
     const char *filenameinzip = filename.c_str();
     const char *savefilenameinzip;
-    zip_fileinfo zi = { };
+    zip_fileinfo zi = {};
     unsigned long crcFile = 0;
     int zip64 = 0;
 
@@ -342,60 +322,59 @@ void compressFiles(std::string root_directory, std::vector<std::string> filename
     while (savefilenameinzip[0] == '\\' || savefilenameinzip[0] == '/')
       savefilenameinzip++;
     /* Should the file be stored with any path info at all? */
-    if (opt_exclude_path)
-    {
+    if (opt_exclude_path) {
       const char *tmpptr = NULL;
       const char *lastslash = 0;
 
-      for (tmpptr = savefilenameinzip; *tmpptr; tmpptr++)
-      {
+      for (tmpptr = savefilenameinzip; *tmpptr; tmpptr++) {
         if (*tmpptr == '\\' || *tmpptr == '/')
           lastslash = tmpptr;
       }
 
       if (lastslash != NULL)
-        savefilenameinzip = lastslash + 1; /* base filename follows last slash. */
+        savefilenameinzip =
+            lastslash + 1; /* base filename follows last slash. */
     }
 
-    // @MarkusR: Updated this call from zipOpenNewFileInZip3_64 for UTF-8 support, 36 and UTF8_FLAG (1<<11) comes from
+    // @MarkusR: Updated this call from zipOpenNewFileInZip3_64 for UTF-8
+    // support, 36 and UTF8_FLAG (1<<11) comes from
     // https://stackoverflow.com/questions/14625784/how-to-convert-minizip-wrapper-to-unicode
     /* Add to zip file */
-    err = zipOpenNewFileInZip4_64(zf, savefilenameinzip, &zi,
-                                  NULL, 0, NULL, 0, NULL /* comment*/,
-                                  (opt_compress_level != 0) ? Z_DEFLATED : 0,
-                                  opt_compress_level, 0,
-                                  /* -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY, */
-                                  -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY,
-                                  password, crcFile, 36, UTF8_FLAG,zip64);
+    err = zipOpenNewFileInZip4_64(
+        zf, savefilenameinzip, &zi, NULL, 0, NULL, 0, NULL /* comment*/,
+        (opt_compress_level != 0) ? Z_DEFLATED : 0, opt_compress_level, 0,
+        /* -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY, */
+        -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY, password, crcFile, 36,
+        UTF8_FLAG, zip64);
 
     if (err != ZIP_OK)
-      writeLogLine(std::string("Could not open '") + savefilenameinzip + "' in zipfile, zlib error: " + toString(err), MODIO_DEBUGLEVEL_ERROR);
-    else
-    {
+      writeLogLine(std::string("Could not open '") + savefilenameinzip +
+                       "' in zipfile, zlib error: " + toString(err),
+                   MODIO_DEBUGLEVEL_ERROR);
+    else {
       fin = modio::platform::fopen(complete_file_path.c_str(), "rb");
-      if (fin == NULL)
-      {
-        writeLogLine(std::string("Could not open '") + complete_file_path + "' for reading", MODIO_DEBUGLEVEL_ERROR);
+      if (fin == NULL) {
+        writeLogLine(std::string("Could not open '") + complete_file_path +
+                         "' for reading",
+                     MODIO_DEBUGLEVEL_ERROR);
       }
     }
 
-    if (err == ZIP_OK)
-    {
+    if (err == ZIP_OK) {
       /* Read contents of file and write it to zip */
-      do
-      {
+      do {
         size_read = fread(buf, 1, size_buf, fin);
-        if ((size_read < size_buf) && (feof(fin) == 0))
-        {
-          writeLogLine(std::string("Error in reading ") + filenameinzip, MODIO_DEBUGLEVEL_ERROR);
+        if ((size_read < size_buf) && (feof(fin) == 0)) {
+          writeLogLine(std::string("Error in reading ") + filenameinzip,
+                       MODIO_DEBUGLEVEL_ERROR);
         }
 
-        if (size_read > 0)
-        {
+        if (size_read > 0) {
           err = zipWriteInFileInZip(zf, buf, (unsigned int)size_read);
-          if (err < 0)
-          {
-            writeLogLine(std::string("Error in writing ") + filenameinzip + " in zipfile, zlib error: " + toString(err), MODIO_DEBUGLEVEL_ERROR);
+          if (err < 0) {
+            writeLogLine(std::string("Error in writing ") + filenameinzip +
+                             " in zipfile, zlib error: " + toString(err),
+                         MODIO_DEBUGLEVEL_ERROR);
           }
         }
       } while ((err == ZIP_OK) && (size_read > 0));
@@ -406,27 +385,29 @@ void compressFiles(std::string root_directory, std::vector<std::string> filename
 
     if (err < 0)
       err = ZIP_ERRNO;
-    else
-    {
+    else {
       err = zipCloseFileInZip(zf);
       if (err != ZIP_OK)
-        writeLogLine(std::string("Error in closing ") + filenameinzip + " in zipfile, zlib error: " + toString(err), MODIO_DEBUGLEVEL_ERROR);
+        writeLogLine(std::string("Error in closing ") + filenameinzip +
+                         " in zipfile, zlib error: " + toString(err),
+                     MODIO_DEBUGLEVEL_ERROR);
     }
   }
 
   errclose = zipClose(zf, NULL);
 
   if (errclose != ZIP_OK)
-    writeLogLine(std::string("Error in closing ") + zipfilename + ", zlib error: " + toString(errclose), MODIO_DEBUGLEVEL_ERROR);
+    writeLogLine(std::string("Error in closing ") + zipfilename +
+                     ", zlib error: " + toString(errclose),
+                 MODIO_DEBUGLEVEL_ERROR);
 
   free(buf);
 }
 
-void compressDirectory(std::string directory, std::string zip_path)
-{
+void compressDirectory(std::string directory, std::string zip_path) {
   directory = modio::addSlashIfNeeded(directory);
   writeLogLine("Compressing directory " + directory, MODIO_DEBUGLEVEL_LOG);
   compressFiles(directory, getFilenames(directory), zip_path);
 }
-}
-}
+} // namespace minizipwrapper
+} // namespace modio

--- a/src/wrappers/MinizipWrapper.cpp
+++ b/src/wrappers/MinizipWrapper.cpp
@@ -147,10 +147,20 @@ void extract(std::string zip_path, std::string directory_path) {
         utf8_encoded_filename = modio::CP437ToUTF8(filename);
       }
     }
+     
+    // If someone has encoded directory delimiters with \ , then convert them to / to ensure
+    // that we manage to create the correct path on all platforms
+    for (int i = 0; i < utf8_encoded_filename.size(); ++i)
+    {
+        if (utf8_encoded_filename[i] == '\\')
+        {
+            utf8_encoded_filename[i] = dir_delimter;
+        }
+    }
 
     strcpy(final_filename, directory_path.c_str());
     strcat(final_filename, utf8_encoded_filename.c_str());
-
+      
     modio::createPath(directory_path + utf8_encoded_filename);
 
     if (utf8_encoded_filename[utf8_encoded_filename.size() - 1] ==

--- a/src/wrappers/MinizipWrapper.cpp
+++ b/src/wrappers/MinizipWrapper.cpp
@@ -51,7 +51,6 @@ std::vector<std::string> getZipFilenames(const std::string &zip_path) {
 
     int err;
     std::string utf8_encoded_filename;
-    char final_filename[MAX_FILENAME];
     // Ensure that filename isn't used after this scope
     {
       char filename[MAX_FILENAME];
@@ -314,6 +313,14 @@ void compressFiles(std::string root_directory,
     /* Get information about the file on disk so we can store it in zip */
     getFileTimeWrapper(complete_file_path, zi);
     zip64 = getIsLargeFile(complete_file_path);
+
+    // All files should have forward slashes in them according to 4.4.17.1
+    // in https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
+    for (int i = 0; i < filename.size(); ++i) {
+      if (filename[i] == '\\') {
+        filename[i] = '/';
+      }
+    }
 
     /* Construct the filename that our file will be stored in the zip as.
           The path name saved, should not include a leading slash.

--- a/test/test_filesystem.cpp
+++ b/test/test_filesystem.cpp
@@ -1,4 +1,4 @@
-﻿#include "Utility.h"
+#include "Utility.h"
 #include "gtest/gtest.h"
 #include "ghc/filesystem.hpp"
 #include "Fixture_CleanupFolders.h"
@@ -82,6 +82,8 @@ TEST_F(FolderBase, CreateRelativeFolderFailure)
   createFolderFailureTest(u8"модио/shouldExist");
 }
 
+// MarkusR: These tests don't work on OS X. But I don't dare to touch them as I'm patching
+// unrelated code. The tests creates folders named "Debug\subfolder" instead of folders "Debug" / "subfolder".
 TEST_F(FolderBase, CreateAbsoluteFolderSuccess)
 {
   // Create directories with forwardslashes in their paths

--- a/test/test_minizip.cpp
+++ b/test/test_minizip.cpp
@@ -1,165 +1,166 @@
+#include "../src/Filesystem.h"
+#include "DATA_Minizip.h"
+#include "Utility.h"
+#include "ghc/filesystem.hpp"
 #include "wrappers/MinizipWrapper.h"
 #include "gtest/gtest.h"
-#include "Utility.h"
-#include "DATA_Minizip.h"
 #include <fstream>
-#include "../src/Filesystem.h"
-#include "ghc/filesystem.hpp"
 
-// I think these tests should be rewritten, as they are way to bloated, and bugs might be in the tests
-class MinizipTests : public ::testing::Test
-{
+// I think these tests should be rewritten, as they are way to bloated, and bugs
+// might be in the tests
+class MinizipTests : public ::testing::Test {
 protected:
-	void SetUp() override
-	{
-	  ghc::filesystem::remove_all("zip");
-	  ghc::filesystem::remove_all("unzip");
-	}
+  void SetUp() override {
+    ghc::filesystem::remove_all("zip");
+    ghc::filesystem::remove_all("unzip");
+  }
 
-	void TearDown() override
-	{
-      ghc::filesystem::remove_all("zip");
-      ghc::filesystem::remove_all("unzip");
-	}
+  void TearDown() override {
+    ghc::filesystem::remove_all("zip");
+    ghc::filesystem::remove_all("unzip");
+  }
 
-	void createZipDataset(const std::map<std::string, std::string>& dataset, const std::string& inFolder)
-	{
-		for (auto& it : dataset)
-		{
-			bool result = modio::createPath(inFolder + "/" + it.first);
-			ASSERT_TRUE(result) << "Failed to create path " << it.first;
-			if (!modio::isDirectory(it.first))
-			{
-				std::ofstream file = modio::platform::ofstream(inFolder + "/" + it.first);
-				file << it.second;
-				file.close();
-			}
-		}
-	}
+  void createZipDataset(const std::map<std::string, std::string> &dataset,
+                        const std::string &inFolder) {
+    for (auto &it : dataset) {
+      bool result = modio::createPath(inFolder + "/" + it.first);
+      ASSERT_TRUE(result) << "Failed to create path " << it.first;
+      if (!modio::isDirectory(it.first)) {
+        std::ofstream file =
+            modio::platform::ofstream(inFolder + "/" + it.first);
+        file << it.second;
+        file.close();
+      }
+    }
+  }
 
-	void compareZipDataset(const std::map<std::string, std::string>& dataset, const std::vector<std::string>& files, std::string filesPath )
-	{
-	  filesPath = modio::addSlashIfNeeded(filesPath);
+  void compareZipDataset(const std::map<std::string, std::string> &dataset,
+                         const std::vector<std::string> &files,
+                         std::string filesPath) {
+    filesPath = modio::addSlashIfNeeded(filesPath);
 
-	  EXPECT_EQ(dataset.size(), files.size()) << "Dataset and file size different";
-	  compareFilenamesWithDataset( dataset, files );
-	  
-	  for( const std::string& file : files )
-	  {
-		std::string datasetContent;
-		if( getDatasetFileContent(dataset, file, datasetContent) )
-		{
-		  std::ifstream stream = modio::platform::ifstream(filesPath + file);
-		  ASSERT_TRUE(stream.is_open()) << "Couldn't open file " << filesPath + file;
-		  
-		  std::string fileContent;
-		  stream.seekg(0, std::ios::end);
-          fileContent.reserve(stream.tellg());
-		  stream.seekg(0, std::ios::beg);
+    EXPECT_EQ(dataset.size(), files.size())
+        << "Dataset and file size different";
+    compareFilenamesWithDataset(dataset, files);
 
-          fileContent.assign( std::istreambuf_iterator<char>(stream),
-							  std::istreambuf_iterator<char>() );
+    for (const std::string &file : files) {
+      std::string datasetContent;
+      if (getDatasetFileContent(dataset, file, datasetContent)) {
+        std::ifstream stream = modio::platform::ifstream(filesPath + file);
+        ASSERT_TRUE(stream.is_open())
+            << "Couldn't open file " << filesPath + file;
 
-		  EXPECT_EQ(fileContent, datasetContent) << "File " << file << " content is different from the content that was written to disk";
-		}
-	  }
-	}
+        std::string fileContent;
+        stream.seekg(0, std::ios::end);
+        fileContent.reserve(stream.tellg());
+        stream.seekg(0, std::ios::beg);
 
-	bool compareFilenamesWithDataset(const std::map<std::string, std::string>& dataset, const std::vector<std::string>& files)
-	{
-	  for (const auto& fileIt : files)
-	  {
-		const std::string& filename = fileIt;
+        fileContent.assign(std::istreambuf_iterator<char>(stream),
+                           std::istreambuf_iterator<char>());
 
-		bool found = false;
-		for (const auto& datasetIt : dataset)
-		{
-		  std::string datasetFilePath( datasetIt.first.size(), ' ' );
-      // All files should have forward slashes in them according to 4.4.17.1 in https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
-		  std::replace_copy(datasetIt.first.begin(), datasetIt.first.end(), datasetFilePath.begin(), '\\', '/');
+        EXPECT_EQ(fileContent, datasetContent)
+            << "File " << file
+            << " content is different from the content that was written to "
+               "disk";
+      }
+    }
+  }
 
-		  if( datasetFilePath == filename )
-		  {
-			found = true;
-			break;
-		  }
-		}
+  bool
+  compareFilenamesWithDataset(const std::map<std::string, std::string> &dataset,
+                              const std::vector<std::string> &files) {
+    for (const auto &fileIt : files) {
+      const std::string &filename = fileIt;
 
-		EXPECT_TRUE(found) << "File " << filename << " has been created that wasn't supposed to have been created";
-		// If the file wasn't present in the file set
-		if( !found )
-		{
-		  return false;
-		}
-	  }
+      bool found = false;
+      for (const auto &datasetIt : dataset) {
+        std::string datasetFilePath(datasetIt.first.size(), ' ');
+        // All files should have forward slashes in them according to 4.4.17.1
+        // in https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
+        std::replace_copy(datasetIt.first.begin(), datasetIt.first.end(),
+                          datasetFilePath.begin(), '\\', '/');
 
-	  for (const auto& datasetIt : dataset)
-      {
-        std::string datasetFilePath( datasetIt.first.size(), ' ' );
-        std::replace_copy(datasetIt.first.begin(), datasetIt.first.end(), datasetFilePath.begin(), '\\', '/');
-
-        bool found = false;
-		    for (const auto& fileIt : files)
-        {
-          const std::string& filename = fileIt;
-
-          if (datasetFilePath == filename)
-          {
-            found = true;
-            break;
-          }
-        }
-
-        EXPECT_TRUE(found) << "File " << datasetFilePath << " from dataset wasn't properly found";
-        // If the file wasn't present in the file set
-        if (!found)
-        {
-          return false;
+        if (datasetFilePath == filename) {
+          found = true;
+          break;
         }
       }
 
-	  return true;
-	}
+      EXPECT_TRUE(found)
+          << "File " << filename
+          << " has been created that wasn't supposed to have been created";
+      // If the file wasn't present in the file set
+      if (!found) {
+        return false;
+      }
+    }
 
-	// Transforms the filename and the dataset filename to all slashes, so we get same files independent on the slashing
-	bool getDatasetFileContent(const std::map<std::string, std::string>& dataset, std::string filename, std::string& out_datasetContent  )
-	{
-	  // Convert all directory separators to /
-	  std::replace(filename.begin(), filename.end(), '\\', '/');
-	  for( const auto& it : dataset )
-	  {
-		std::string datasetFilePath( it.first.size(), ' ' );
-		std::replace_copy(it.first.begin(), it.first.end(), datasetFilePath.begin(), '\\', '/');
-		
-		if( filename == datasetFilePath )
-		{
-		  out_datasetContent = it.second;
-		  return true;
-		}
-	  }
+    for (const auto &datasetIt : dataset) {
+      std::string datasetFilePath(datasetIt.first.size(), ' ');
+      std::replace_copy(datasetIt.first.begin(), datasetIt.first.end(),
+                        datasetFilePath.begin(), '\\', '/');
 
-	  out_datasetContent = "";
-	  return false;
-	}
+      bool found = false;
+      for (const auto &fileIt : files) {
+        const std::string &filename = fileIt;
+
+        if (datasetFilePath == filename) {
+          found = true;
+          break;
+        }
+      }
+
+      EXPECT_TRUE(found) << "File " << datasetFilePath
+                         << " from dataset wasn't properly found";
+      // If the file wasn't present in the file set
+      if (!found) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  // Transforms the filename and the dataset filename to all slashes, so we get
+  // same files independent on the slashing
+  bool getDatasetFileContent(const std::map<std::string, std::string> &dataset,
+                             std::string filename,
+                             std::string &out_datasetContent) {
+    // Convert all directory separators to /
+    std::replace(filename.begin(), filename.end(), '\\', '/');
+    for (const auto &it : dataset) {
+      std::string datasetFilePath(it.first.size(), ' ');
+      std::replace_copy(it.first.begin(), it.first.end(),
+                        datasetFilePath.begin(), '\\', '/');
+
+      if (filename == datasetFilePath) {
+        out_datasetContent = it.second;
+        return true;
+      }
+    }
+
+    out_datasetContent = "";
+    return false;
+  }
 };
 
-//void extract(std::string zip_path, std::string directory_path);
-//void compressDirectory(std::string directory, std::string zip_path);
-//void compressFiles(std::string root_directory, std::vector<std::string> filenames, std::string zip_path);
+// void extract(std::string zip_path, std::string directory_path);
+// void compressDirectory(std::string directory, std::string zip_path);
+// void compressFiles(std::string root_directory, std::vector<std::string>
+// filenames, std::string zip_path);
 
-TEST_F(MinizipTests, TestCompressFiles)
-{
-	createZipDataset(modio::fileToContent, "zip");
-	modio::minizipwrapper::compressFiles( "zip", modio::getFilenames("zip"), "zippity.zip");
-	modio::minizipwrapper::extract("zippity.zip", "unzip");
+TEST_F(MinizipTests, TestCompressFiles) {
+  createZipDataset(modio::fileToContent, "zip");
+  modio::minizipwrapper::compressFiles("zip", modio::getFilenames("zip"),
+                                       "zippity.zip");
+  modio::minizipwrapper::extract("zippity.zip", "unzip");
 
-	std::vector<std::string> files;
-	for( auto& it : ghc::filesystem::recursive_directory_iterator( "unzip" ) )
-	{
-	  if( !it.is_directory() )
-	  {
-		files.push_back( ghc::filesystem::relative( it.path(), "unzip" ).generic_u8string() );
-	  }
-	}
-	compareZipDataset(modio::fileToContent, files, "unzip");	
+  std::vector<std::string> files;
+  for (auto &it : ghc::filesystem::recursive_directory_iterator("unzip")) {
+    if (!it.is_directory()) {
+      files.push_back(
+          ghc::filesystem::relative(it.path(), "unzip").generic_u8string());
+    }
+  }
+  compareZipDataset(modio::fileToContent, files, "unzip");
 }

--- a/test/test_minizip.cpp
+++ b/test/test_minizip.cpp
@@ -69,13 +69,13 @@ protected:
 	{
 	  for (const auto& fileIt : files)
 	  {
-		std::string filename( fileIt.size(), ' ' );
-		// Convert all directory separators to /
-		std::replace_copy(fileIt.begin(), fileIt.end(), filename.begin(), '\\', '/');
+		const std::string& filename = fileIt;
+
 		bool found = false;
 		for (const auto& datasetIt : dataset)
 		{
 		  std::string datasetFilePath( datasetIt.first.size(), ' ' );
+      // All files should have forward slashes in them according to 4.4.17.1 in https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
 		  std::replace_copy(datasetIt.first.begin(), datasetIt.first.end(), datasetFilePath.begin(), '\\', '/');
 
 		  if( datasetFilePath == filename )
@@ -85,7 +85,7 @@ protected:
 		  }
 		}
 
-		EXPECT_TRUE(found) << "File " << filename << " has been created that wasn't suppoed to have been created";
+		EXPECT_TRUE(found) << "File " << filename << " has been created that wasn't supposed to have been created";
 		// If the file wasn't present in the file set
 		if( !found )
 		{
@@ -99,11 +99,9 @@ protected:
         std::replace_copy(datasetIt.first.begin(), datasetIt.first.end(), datasetFilePath.begin(), '\\', '/');
 
         bool found = false;
-		for (const auto& fileIt : files)
+		    for (const auto& fileIt : files)
         {
-          std::string filename( fileIt.size(), ' ' );
-          // Convert all directory separators to /
-          std::replace_copy(fileIt.begin(), fileIt.end(), filename.begin(), '\\', '/');
+          const std::string& filename = fileIt;
 
           if (datasetFilePath == filename)
           {


### PR DESCRIPTION
Zip files was encoded with \ instead of / witch is not comliant with the standard.
Also added backport compability so that the sdk can properly extract zip-files with \ instead of /